### PR TITLE
Build dir startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ This plugin connects to the instance via url eg. `https://engine.anomalizer.app`
 - `npm start`
 
 ### Start Docker
-- `docker run -d -p 3000:3000 -v "$(pwd)"/dist:/var/lib/grafana/plugins --name=grafana grafana/grafana:7.0.0`
+- `npm run docker-init`
 - Follow the instructions from `Getting Started - Build the Panel` to initialize the panels

--- a/buildPath.txt
+++ b/buildPath.txt
@@ -1,0 +1,1 @@
+/tmp/grafana_plugins/

--- a/buildPath.txt
+++ b/buildPath.txt
@@ -1,1 +1,0 @@
-/tmp/grafana_plugins/

--- a/grafanaPluginDirectory.txt
+++ b/grafanaPluginDirectory.txt
@@ -1,0 +1,1 @@
+/tmp/pogadog_grafana_plugins/

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "watch": "grafana-toolkit plugin:dev --watch",
     "sign": "grafana-toolkit plugin:sign --rootUrls http://localhost:3000",
     "start": "npm run watch",
-    "docker-init": "docker run -d -p 3000:3000 -v $(cat buildPath.txt):/var/lib/grafana/plugins --name=grafana-anomalizer grafana/grafana:7.0.0"
+    "docker-init": "docker run -d -p 3000:3000 -v $(cat grafanaPluginDirectory.txt):/var/lib/grafana/plugins --name=grafana-anomalizer grafana/grafana:7.0.0"
   },
   "author": "Pogadog, LLC",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "grafana-toolkit plugin:dev && cp -r dist grafana-plugins/dist",
     "watch": "grafana-toolkit plugin:dev --watch",
     "sign": "grafana-toolkit plugin:sign --rootUrls http://localhost:3000",
-    "start": "npm run watch"
+    "start": "npm run watch",
+    "docker-init": "docker run -d -p 3000:3000 -v $(cat buildPath.txt):/var/lib/grafana/plugins --name=grafana-anomalizer grafana/grafana:7.0.0"
   },
   "author": "Pogadog, LLC",
   "license": "Apache-2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,6 @@ module.exports = (config, options) => {
         type: 'asset',
     })
     let buildPath = fs.readFileSync("./buildPath.txt", 'utf-8');
-    config.output.path = path.resolve(__dirname,  buildPath + '/anomalizer-grafana-plugin');
+    config.output.path = path.resolve(buildPath + '/anomalizer-grafana-plugin');
     return config;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-const path = require("path");
+
 const fs = require("fs");
 const exec = require('child_process').exec;
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = (config, options) => {
         apply: (compiler) => {
             compiler.hooks.afterEmit.tap('AfterEmitPlugin', (compilation) => {
                 let buildPath = fs.readFileSync("./grafanaPluginDirectory.txt", 'utf-8');
-                exec(`cp -r dist/ ${buildPath}/pogadog-anomalizer-panel`, (err, stdout, stderr) => {
+                exec(`mkdir -p ${buildPath}/pogadog-anomalizer-panel && cp -r dist/ ${buildPath}/pogadog-anomalizer-panel`, (err, stdout, stderr) => {
                     process.stdout.write(`  Plugin successfully copied to ${buildPath}\n`);
                 });
             });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,11 +3,14 @@ const fs = require("fs");
 const exec = require('child_process').exec;
 
 module.exports = (config, options) => {
+
+    // correctly include svgs as base64 assets
     config.module.rules.push({
         test: /\.svg/,
         type: 'asset',
     })
 
+    // copy built plugin to shared Grafana Docker plugin directory
     config.plugins.push({
         apply: (compiler) => {
             compiler.hooks.afterEmit.tap('AfterEmitPlugin', (compilation) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,12 @@
+const path = require("path");
+const fs = require("fs");
 
 module.exports = (config, options) => {
     config.module.rules.push({
         test: /\.svg/,
         type: 'asset',
     })
+    let buildPath = fs.readFileSync("./buildPath.txt", 'utf-8');
+    config.output.path = path.resolve(__dirname,  buildPath + '/anomalizer-grafana-plugin');
     return config;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,23 @@
 const path = require("path");
 const fs = require("fs");
+const exec = require('child_process').exec;
 
 module.exports = (config, options) => {
     config.module.rules.push({
         test: /\.svg/,
         type: 'asset',
     })
-    let buildPath = fs.readFileSync("./buildPath.txt", 'utf-8');
-    config.output.path = path.resolve(buildPath + '/anomalizer-grafana-plugin');
+
+    config.plugins.push({
+        apply: (compiler) => {
+            compiler.hooks.afterEmit.tap('AfterEmitPlugin', (compilation) => {
+                let buildPath = fs.readFileSync("./grafanaPluginDirectory.txt", 'utf-8');
+                exec(`cp -r dist/ ${buildPath}/pogadog-anomalizer-panel`, (err, stdout, stderr) => {
+                    process.stdout.write(`  Plugin successfully copied to ${buildPath}\n`);
+                });
+            });
+        }
+      })
+
     return config;
 }


### PR DESCRIPTION
So this pull request is in preparation of developing the Data Source plugin.

The Grafana development Docker instance will now read the Panel Plugin and the Data Source plugin from a shared directory, allowing for concurrent usage/development of the plugins from within the same Docker instance.

These changes simply provision the Docker instance differently, along with copying the compiled plugin to the new shared plugin directory upon each compilation in Webpack.

Let me know if these changes work for you. You'll need to remove any existing `grafana-anomalizer` Docker container.